### PR TITLE
Implement algorithms (2) and (3) from AA

### DIFF
--- a/CalendarConverterLib/CalendarConverter.cs
+++ b/CalendarConverterLib/CalendarConverter.cs
@@ -119,10 +119,32 @@ namespace GKCommon
             int x4 = year + c0;
             int x3 = downwardRounding(x4, 100);
             int x2 = x4 - 100 * x3;
-            int x1 = month - 12 * c0 - 3;
+            int x1 = month - 3 - 12 * c0;
             return (uint) (downwardRounding(146097 * x3, 4) +
                            downwardRounding(36525 * x2, 100) +
                            downwardRounding(153 * x1 + 2, 5) + day + 1721119);
+        }
+
+        public static uint gregorian_to_jd4(int year, int month, int day)
+        {
+          int c3 = downwardRounding(month - 3, 12);
+          int x1 = month - 3 - 12 * c3;
+          int z2 = downwardRounding(153 * x1 + 2, 5) + day - 1;
+          int x2 = year + c3;
+          int c2 = 365 * x2 + downwardRounding(x2, 4) -
+                   downwardRounding(x2, 100) + downwardRounding(x2, 400);
+          return (uint) (c2 + z2 + 1721120);
+        }
+
+        public static uint gregorian_to_jd5(int year, int month, int day)
+        {
+          int x2 = 12 * year + month - 1;
+          int c2 = 30 * x2 + downwardRounding(7 * x2 + 5, 12) -
+                   2 * downwardRounding(x2 + 10, 12) +
+                   downwardRounding(x2 + 46, 48) -
+                   downwardRounding(x2 + 1198, 1200) +
+                   downwardRounding(x2 + 4798, 4800);
+          return (uint) (c2 + day - 1 + 1721060);
         }
 
         public static void jd_to_gregorian2(double jd, out int year, out int month, out int day)
@@ -156,6 +178,56 @@ namespace GKCommon
             int c0 = downwardRounding(x1 + 2, 12);
             month = x1 - 12 * c0 + 3;
             year = 100 * x3 + x2 + c0;
+        }
+
+        public static void jd_to_gregorian4(uint jd, out int year,
+                                            out int month, out int day)
+        {
+          int sjd = (int) (jd);
+          int y2 = sjd - 1721120;
+          int x2 = downwardRounding(400 * y2 + 799, 146097);
+          int c2 = 365 * x2 + downwardRounding(x2, 4) -
+                   downwardRounding(x2, 100) + downwardRounding(x2, 400);
+          int z2 = y2 - c2;
+          int zeta = downwardRounding(z2, 367);
+          x2 += zeta;
+          c2 = 365 * x2 + downwardRounding(x2, 4) - downwardRounding(x2, 100) +
+               downwardRounding(x2, 400);
+          z2 = y2 - c2;
+          int x1 = downwardRounding(5 * z2 + 2, 153);
+          int c1 = downwardRounding(153 * x1 + 2, 5);
+          int z1 = z2 - c1;
+          int c0 = downwardRounding(x1 + 2, 12);
+          year = x2 + c0;
+          month = x1 - 12 * c0 + 3;
+          day = z1 + 1;
+        }
+
+        public static void jd_to_gregorian5(uint jd, out int year,
+                                            out int month, out int day)
+        {
+          int sjd = (int) (jd);
+          int y2 = sjd - 1721060;
+          int x2 = downwardRounding(4800 * y2 + 15793, 146097);
+          int c2 = 30 * x2 + downwardRounding(7 * x2 + 5, 12) -
+                   2 * downwardRounding(x2 + 10, 12) +
+                   downwardRounding(x2 + 46, 48) -
+                   downwardRounding(x2 + 1198, 1200) +
+                   downwardRounding(x2 + 4798, 4800);
+          int z2 = y2 - c2;
+          int zeta = downwardRounding(z2, 33);
+          x2 += zeta;
+          c2 = 30 * x2 + downwardRounding(7 * x2 + 5, 12) -
+               2 * downwardRounding(x2 + 10, 12) +
+               downwardRounding(x2 + 46, 48) -
+               downwardRounding(x2 + 1198, 1200) +
+               downwardRounding(x2 + 4798, 4800);
+          z2 = y2 - c2;
+          int x1 = downwardRounding(x2, 12);
+          int z1 = x2 - 12 * x1;
+          year = x1;
+          month = z1 + 1;
+          day = z2 + 1;
         }
 
         #endregion

--- a/CalendarConverterLib/UDN.cs
+++ b/CalendarConverterLib/UDN.cs
@@ -122,7 +122,7 @@ namespace GKCommon
                 }
 
                 return result;
-            } catch (Exception ex) {
+            } catch (Exception) {
                 System.Diagnostics.Debug.WriteLine("UDN.ToString()");
                 return "";
             }

--- a/UDNTest/Program.cs
+++ b/UDNTest/Program.cs
@@ -230,7 +230,6 @@ namespace UDNTest
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 1));
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 15));
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 31));
-/*
             dates.Add(new date(UDNCalendarType.ctJulian, -1, 10, 15));
             dates.Add(new date(UDNCalendarType.ctJulian, 0, 10, 15));
             dates.Add(new date(UDNCalendarType.ctJulian, 1, 10, 15));
@@ -250,7 +249,6 @@ namespace UDNTest
             dates.Add(new date(UDNCalendarType.ctHebrew, 3762, 12, 2));
             dates.Add(new date(UDNCalendarType.ctHebrew, 3762, 13, 29));
             dates.Add(new date(UDNCalendarType.ctHebrew, 3763, 1, 1));
-*/
             Console.WriteLine("\nCheck does a JDN algorithm make reversible dates");
             widths = new int[] {32, 48, 35};
             format =

--- a/UDNTest/Program.cs
+++ b/UDNTest/Program.cs
@@ -212,6 +212,13 @@ namespace UDNTest
             #endif
 
             List<date> dates = new List<date>();
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4713, 11, 24));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4712, 1, 2));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4712, 1, 3));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4700, 2, 28));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4528, 2, 29));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4528, 2, 28));
+            dates.Add(new date(UDNCalendarType.ctGregorian, -4529, 2, 28));
             dates.Add(new date(UDNCalendarType.ctGregorian, -1, 1, 25));
             dates.Add(new date(UDNCalendarType.ctGregorian, 0, 1, 25));
             dates.Add(new date(UDNCalendarType.ctGregorian, 1, 1, 25));
@@ -223,6 +230,7 @@ namespace UDNTest
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 1));
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 15));
             dates.Add(new date(UDNCalendarType.ctGregorian, 2016, 7, 31));
+/*
             dates.Add(new date(UDNCalendarType.ctJulian, -1, 10, 15));
             dates.Add(new date(UDNCalendarType.ctJulian, 0, 10, 15));
             dates.Add(new date(UDNCalendarType.ctJulian, 1, 10, 15));
@@ -242,8 +250,9 @@ namespace UDNTest
             dates.Add(new date(UDNCalendarType.ctHebrew, 3762, 12, 2));
             dates.Add(new date(UDNCalendarType.ctHebrew, 3762, 13, 29));
             dates.Add(new date(UDNCalendarType.ctHebrew, 3763, 1, 1));
+*/
             Console.WriteLine("\nCheck does a JDN algorithm make reversible dates");
-            widths = new int[] {32, 48, 34};
+            widths = new int[] {32, 48, 35};
             format =
                 #if LEFT_AND_RIGHT_BORDERS
                 string.Format("{{3}} {{0, {0}}} {{3}} {{1, {1}}} {{3}} {{2, {2}}} {{3}}", widths[0], widths[1], widths[2]);
@@ -275,19 +284,60 @@ namespace UDNTest
                 char ok;
                 if (UDNCalendarType.ctGregorian == d.calendar)
                 {
-                    uint jdn = CalendarConverter.gregorian_to_jd3(d.year, d.month, d.day);
-                    CalendarConverter.jd_to_gregorian3(jdn, out year, out month, out day);
+                    uint jdn;
+                    string reconstructed;
+                    try
+                    {
+                      jdn = CalendarConverter.gregorian_to_jd5(d.year, d.month, d.day);
+                      CalendarConverter.jd_to_gregorian5(jdn, out year, out month, out day);
+                      recDate = string.Format("{0}/{1}/{2}", year, month, day);
+                      ok = (recDate == original) ? '+' : 'o';
+                      reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
+                    }
+                    catch (Exception)
+                    {
+                      jdn = 0;
+                      ok = 'o';
+                      reconstructed = "**** error";
+                    }
+                    a = new Object[] {original, "by `gregorian_to_jd5`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    Console.WriteLine(format, a);
+                    jdn = CalendarConverter.gregorian_to_jd4(d.year, d.month, d.day);
+                    CalendarConverter.jd_to_gregorian4(jdn, out year, out month, out day);
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
-                    string reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_gregorian3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
+                    a = new Object[] {original, "by `gregorian_to_jd4`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    Console.WriteLine(format, a);
+                    try
+                    {
+                      jdn = CalendarConverter.gregorian_to_jd3(d.year, d.month, d.day);
+                      CalendarConverter.jd_to_gregorian3(jdn, out year, out month, out day);
+                      recDate = string.Format("{0}/{1}/{2}", year, month, day);
+                      ok = (recDate == original) ? '+' : 'o';
+                      reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
+                    }
+                    catch (Exception)
+                    {
+                      jdn = 0;
+                      ok = 'o';
+                      reconstructed = "**** error";
+                    }
+                    a = new Object[] {original, "by `gregorian_to_jd3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    Console.WriteLine(format, a);
+                    jdn = (uint)CalendarConverter.gregorian_to_jd2(d.year, d.month, d.day);
+                    CalendarConverter.jd_to_gregorian2(jdn, out year, out month, out day);
+                    recDate = string.Format("{0}/{1}/{2}", year, month, day);
+                    ok = (recDate == original) ? '+' : 'o';
+                    reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
+                    a = new Object[] {original, "by `gregorian_to_jd2`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                     jdn = (uint)CalendarConverter.gregorian_to_jd(d.year, d.month, d.day);
                     CalendarConverter.jd_to_gregorian(jdn, out year, out month, out day);
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_gregorian`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `gregorian_to_jd`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                 }
                 else if (UDNCalendarType.ctJulian == d.calendar)
@@ -297,14 +347,14 @@ namespace UDNTest
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     string reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_julian3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `julian_to_jd3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                     jdn = (uint)CalendarConverter.julian_to_jd(d.year, d.month, d.day);
                     CalendarConverter.jd_to_julian(jdn, out year, out month, out day);
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_julian`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `julian_to_jd`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                 }
                 else if (UDNCalendarType.ctIslamic == d.calendar)
@@ -314,14 +364,14 @@ namespace UDNTest
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     string reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_islamic3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `islamic_to_jd3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                     jdn = (uint)CalendarConverter.islamic_to_jd(d.year, d.month, d.day);
                     CalendarConverter.jd_to_islamic(jdn, out year, out month, out day);
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_islamic`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `islamic_to_jd`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                 }
                 else if (UDNCalendarType.ctHebrew == d.calendar)
@@ -331,14 +381,14 @@ namespace UDNTest
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     string reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_hebrew3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `hebrew_to_jd3`: " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                     jdn = (uint)CalendarConverter.hebrew_to_jd(d.year, d.month, d.day);
                     CalendarConverter.jd_to_hebrew(jdn, out year, out month, out day);
                     recDate = string.Format("{0}/{1}/{2}", year, month, day);
                     ok = (recDate == original) ? '+' : 'o';
                     reconstructed = string.Format("{0}/{1}/{2} (must be {3})", year, month, day, original);
-                    a = new Object[] {original, "by `jd_to_hebrew`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
+                    a = new Object[] {original, "by `hebrew_to_jd`:  " + jdn.ToString(), reconstructed + " " + ok, "|"};
                     Console.WriteLine(format, a);
                 }
                 if (dates.Count - 1 > i)


### PR DESCRIPTION
This commit implements the following algorithms from [Astronomy Answers page](http://aa.quae.nl/en/reken/juliaansedag.html):

- http://aa.quae.nl/en/reken/juliaansedag.html#13_2_3
- http://aa.quae.nl/en/reken/juliaansedag.html#13_2_5

The both implementations give very bad results.

Change log:

2016-09-20 Ruslan Garipov <brigadir15@gmail.com>

  * CalendarConverterLib/CalendarConverter.cs (gregorian_to_jd3): Change operands order.
(gregorian_to_jd4, gregorian_to_jd5, jd_to_gregorian4, jd_to_gregorian5): Add new methods.
  * CalendarConverterLib/UDN.cs (ToString): Remove unnecessary variable declaration.
  * UDNTest/Program.cs (Main): Add new dates to tests. Add new functions (`gregorian_to_jd4`, `gregorian_to_jd5`, `jd_to_gregorian4`, `jd_to_gregorian5`) to tests.

Signed-off-by: Ruslan Garipov <brigadir15@gmail.com>